### PR TITLE
Universal id

### DIFF
--- a/server/setup/setup_database.sql
+++ b/server/setup/setup_database.sql
@@ -18,12 +18,12 @@ GRANT USAGE ON SCHEMA public TO imaging_server;
 /* Step 2: create all the tables */
 
 CREATE TABLE "public"."incoming_image" (
-  id serial NOT NULL,
+  image_id serial NOT NULL,
   time_stamp timestamp NOT NULL,
   image_path text NOT NULL,
   manual_tap boolean NOT NULL default FALSE,
   autonomous_tap boolean NOT NULL default FALSE,
-  PRIMARY KEY ("id")
+  PRIMARY KEY ("image_id")
 );
 
 CREATE TABLE "public"."incoming_gps" (
@@ -46,18 +46,19 @@ CREATE TABLE "public"."incoming_state" (
 
 CREATE TABLE "public"."manual_cropped" (
   id serial NOT NULL,
-  raw_id int,
+  image_id int NOT NULL,
   time_stamp timestamp NOT NULL,
   cropped_path text NOT NULL,
   crop_coordinate_tl point,
   crop_coordinate_br point,
   tapped boolean NOT NULL default FALSE,
-  PRIMARY KEY ("id")
+  PRIMARY KEY ("id"),
+  UNIQUE ("image_id")
 );
 
 CREATE TABLE "public"."outgoing_manual" (
   id serial NOT NULL,
-  cropped_id int NOT NULL,
+  image_id int NOT NULL,
   type text NOT NULL CHECK(type = 'Standard' OR type = 'off_axis' OR type = 'emergent'),
   latitude real NOT NULL,
   longitude real NOT NULL,
@@ -69,11 +70,13 @@ CREATE TABLE "public"."outgoing_manual" (
   description text default '',
   cropped_path text NOT NULL,
   submitted boolean NOT NULL default FALSE,
-  PRIMARY KEY ("id")
+  PRIMARY KEY ("id"),
+  UNIQUE ("image_id")
 );
 
 CREATE TABLE "public"."outgoing_autonomous" (
   id serial NOT NULL,
+  image_id int NOT NULL,
   type text NOT NULL CHECK(type = 'Standard' OR type = 'off_axis' OR type = 'emergent'),
   latitude real NOT NULL,
   longitude real NOT NULL,

--- a/server/src/config.py
+++ b/server/src/config.py
@@ -34,7 +34,7 @@ def defaultCroppedImgPath():
 def defaultRawImgPath():
     latestSubDir = getLatestBaseImgDir()
     latestSubDir += '/raw/'
-    if not os.path.exists(latestSubDir)
+    if not os.path.exists(latestSubDir):
         os.makedirs(latestSubDir)
     return latestSubDir
  

--- a/server/src/dao/incoming_image_dao.py
+++ b/server/src/dao/incoming_image_dao.py
@@ -16,7 +16,10 @@ class IncomingImageDAO(BaseDAO):
         @rtype: int
         @return: Id of image if successfully inserted, otherwise -1
         """
-        insertStmt = "INSERT INTO incoming_image (time_stamp, image_path, manual_tap, autonomous_tap) VALUES(to_timestamp(%s), %s, %s, %s) RETURNING id;"
+        insertStmt = """INSERT INTO incoming_image 
+            (time_stamp, image_path, manual_tap, autonomous_tap) 
+            VALUES(to_timestamp(%s), %s, %s, %s) 
+            RETURNING image_id;"""
         return super(IncomingImageDAO, self).getResultingId(insertStmt, incomingImage.insertValues())
 
     def getImage(self, id):
@@ -29,9 +32,9 @@ class IncomingImageDAO(BaseDAO):
         @rtype: incoming_image
         @return: An incoming_image with the info for that image if successfully found, otherwise None
         """
-        selectImgById = """SELECT id, date_part('epoch', time_stamp), image_path, manual_tap, autonomous_tap 
+        selectImgById = """SELECT image_id, date_part('epoch', time_stamp), image_path, manual_tap, autonomous_tap 
             FROM incoming_image 
-            WHERE id = %s 
+            WHERE image_id = %s 
             LIMIT 1;"""
         selectedImage = super(IncomingImageDAO, self).basicTopSelect(selectImgById, (id,))
         
@@ -55,21 +58,21 @@ class IncomingImageDAO(BaseDAO):
         if manual:
             updateStmt = """UPDATE incoming_image 
                 SET manual_tap = TRUE 
-                WHERE id = (
-                    SELECT id 
+                WHERE image_id = (
+                    SELECT image_id 
                     FROM incoming_image 
                     WHERE manual_tap = FALSE 
-                    ORDER BY id LIMIT 1
-                ) RETURNING id;"""
+                    ORDER BY image_id LIMIT 1
+                ) RETURNING image_id;"""
         else:
             updateStmt = """UPDATE incoming_image 
                 SET autonomous_tap = TRUE 
-                WHERE id = (
-                    SELECT id 
+                WHERE image_id = (
+                    SELECT image_id 
                     FROM incoming_image 
                     WHERE autonomous_tap = FALSE 
-                    ORDER BY id LIMIT 1
-                ) RETURNING id;"""
+                    ORDER BY image_id LIMIT 1
+                ) RETURNING image_id;"""
 
         cur = self.conn.cursor()
         cur.execute(updateStmt)

--- a/server/src/dao/model/incoming_image.py
+++ b/server/src/dao/model/incoming_image.py
@@ -2,18 +2,18 @@ class incoming_image:
 
     def __init__(self, tableValues=None):
         if tableValues is not None:
-            self.id = tableValues[0]
+            self.image_id = tableValues[0]
             self.time_stamp = tableValues[1]
             self.image_path = tableValues[2]
             self.manual_tap = tableValues[3]
             self.autonomous_tap = tableValues[4]
 
     @property
-    def id(self):
+    def image_id(self):
         return self._id
 
-    @id.setter
-    def id(self, id):
+    @image_id.setter
+    def image_id(self, id):
         self._id = id
 
     @property
@@ -64,4 +64,4 @@ class incoming_image:
             \ttime_stamp: {}\n
             \timage_path: {}\n
             \tmanual_tap: {}\n
-            \tautonomous_tap: {}""".format(self.id, self.time_stamp, self.image_path, self.manual_tap, self.autonomous_tap)
+            \tautonomous_tap: {}""".format(self.image_id, self.time_stamp, self.image_path, self.manual_tap, self.autonomous_tap)

--- a/server/src/dao/model/manual_cropped.py
+++ b/server/src/dao/model/manual_cropped.py
@@ -5,7 +5,7 @@ class manual_cropped:
     def __init__(self, tableValues=None, json=None):
         if tableValues is not None:
             self.id = tableValues[0]
-            self.raw_id = tableValues[1]
+            self.image_id = tableValues[1]
             self.time_stamp = tableValues[2]
             self.cropped_path = tableValues[3]
             self.crop_coordinate_tl = point(ptStr=tableValues[4])
@@ -28,7 +28,7 @@ class manual_cropped:
         else:
             # defaults:
             self.id = -1
-            self.raw_id = -1
+            self.image_id = -1
             self.tapped = False
 
     @property
@@ -40,12 +40,12 @@ class manual_cropped:
         self._id = id
 
     @property
-    def raw_id(self):
-        return self._raw_id
+    def image_id(self):
+        return self._image_id
 
-    @raw_id.setter
-    def raw_id(self, raw_id):
-        self._raw_id = raw_id
+    @image_id.setter
+    def image_id(self, image_id):
+        self._image_id = image_id
     
     @property
     def time_stamp(self):    
@@ -88,7 +88,7 @@ class manual_cropped:
         self._tapped = tapped
 
     def allProps(self):
-        return ['id', 'raw_id', 'time_stamp', 'cropped_path', 'crop_coordinate_tl', 'crop_coordinate_br', 'tapped']
+        return ['id', 'image_id', 'time_stamp', 'cropped_path', 'crop_coordinate_tl', 'crop_coordinate_br', 'tapped']
 
     def toDict(self):
         dict = {}
@@ -115,4 +115,4 @@ class manual_cropped:
         return dict
 
     def insertValues(self):
-        return [self.raw_id, self.time_stamp, self.cropped_path, self.tapped]
+        return [self.image_id, self.time_stamp, self.cropped_path, self.tapped]


### PR DESCRIPTION
Moving to a universal image id: An id that is created when an image is first inserted into 'incoming_image', and then referenced in all the other manual tables. This makes accessing different state data on a particular image more intuitive and a bit easier to handle client-side.

This also hides the PK id in the other tables(manual_cropped and outgoing_manual). Essentially the idea is that client-side all stages from raw -> cropped -> classified are handled with a singe id